### PR TITLE
Remove parse "parameter" in "periods" from json results of api/qualitygates/project_status. (SonarQube 7.2.1)

### DIFF
--- a/sonar-qualitygates-plugin/pom.xml
+++ b/sonar-qualitygates-plugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.thoughtworks.go</groupId>
     <artifactId>gocd-sonar-qualitygates-plugin</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.thoughtworks.go</groupId>
             <artifactId>gocd-plugin-common</artifactId>
-            <version>${project.version}</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/sonar-qualitygates-plugin/src/com/tw/go/task/sonarqualitygate/SonarTaskExecutor.java
+++ b/sonar-qualitygates-plugin/src/com/tw/go/task/sonarqualitygate/SonarTaskExecutor.java
@@ -53,7 +53,7 @@ public class SonarTaskExecutor extends TaskExecutor {
             JSONObject lastPeriod = (JSONObject) periods.get(periods.length() - 1);
 
             String lastDate = (String) lastPeriod.get("date");
-            String lastVersion = (String) lastPeriod.get("parameter");
+//            String lastVersion = (String) lastPeriod.get("parameter");
 
             if (!("".equals(stageName)) && !("".equals(jobName)) && !("".equals(jobCounter))) {
                 String scheduledTime = getScheduledTime();
@@ -83,7 +83,7 @@ public class SonarTaskExecutor extends TaskExecutor {
                         log("No new scan has been found !");
 
                         log("Date of Sonar scan: " + lastDate);
-                        log("Version of Sonar scan: " + lastVersion);
+//                        log("Version of Sonar scan: " + lastVersion);
 
                         return new Result(false, "Failed to get a newer quality gate for " + sonarProjectKey
                                 + ". The present quality gate is older than the start of the Sonar scan task.");
@@ -94,7 +94,7 @@ public class SonarTaskExecutor extends TaskExecutor {
                 }
 
                 log("Date of Sonar scan: " + lastDate);
-                log("Version of Sonar scan: " + lastVersion);
+//                log("Version of Sonar scan: " + lastVersion);
 
                 SonarParser parser = new SonarParser(result);
 
@@ -108,7 +108,7 @@ public class SonarTaskExecutor extends TaskExecutor {
             else {
 
                 log("Date of Sonar scan: " + lastDate);
-                log("Version of Sonar scan: " + lastVersion);
+//                log("Version of Sonar scan: " + lastVersion);
 
                 SonarParser parser = new SonarParser(result);
 

--- a/sonar-qualitygates-plugin/test/com/tw/go/task/sonarqualitygate/SonarClientTest.java
+++ b/sonar-qualitygates-plugin/test/com/tw/go/task/sonarqualitygate/SonarClientTest.java
@@ -42,9 +42,9 @@ public class SonarClientTest {
         SonarParser parser = new SonarParser(result);
 
         // check that a quality gate is returned
-        JSONObject qgDetails = parser.GetQualityGateDetails();
-
-        String qgResult = qgDetails.getString("level");
+//        JSONObject qgDetails = parser.GetQualityGateDetails();
+//        String qgResult = qgDetails.getString("level");
+        String qgResult = parser.getProjectQualityGateStatus();
         Assert.assertEquals("ERROR", qgResult);
     }
 


### PR DESCRIPTION
I use SonarQube version 7.2.1 and had the same issue here https://github.com/Haufe-Lexware/gocd-plugins/issues/22#issuecomment-396243671

The json result from sonarqube server (version 7.2.1) api (api/qualitygates/project_status?projectKey=....) are following:

> 
{
  "projectStatus": {
    "status": "ERROR",
    "conditions": [
      {
        "status": "ERROR",
        "metricKey": "new_security_rating",
        "comparator": "GT",
        "periodIndex": 1,
        "errorThreshold": "1",
        "actualValue": "2"
      },
      {
        "status": "ERROR",
        "metricKey": "new_reliability_rating",
        "comparator": "GT",
        "periodIndex": 1,
        "errorThreshold": "1",
        "actualValue": "5"
      },
      {
        "status": "OK",
        "metricKey": "new_maintainability_rating",
        "comparator": "GT",
        "periodIndex": 1,
        "errorThreshold": "1",
        "actualValue": "1"
      },
      {
        "status": "ERROR",
        "metricKey": "new_coverage",
        "comparator": "LT",
        "periodIndex": 1,
        "errorThreshold": "80",
        "actualValue": "26.358148893360163"
      },
      {
        "status": "ERROR",
        "metricKey": "new_duplicated_lines_density",
        "comparator": "GT",
        "periodIndex": 1,
        "errorThreshold": "3",
        "actualValue": "3.0048400107555793"
      }
    ],
    "periods": [
      {
        "index": 1,
        "mode": "previous_version",
        "date": "2018-07-23T08:52:34+0000"
      }
    ],
    "ignoredConditions": false
  }
}
> 

**No "parameter" in "periods"**